### PR TITLE
fix: "make install" fails due to directory not existing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ woof-linux-arm:
 
 .PHONY: install
 install: woof-linux-amd64
+	mkdir -p ~/.local/bin
 	mv woof-linux-amd64 ~/.local/bin/woof
 
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,5 @@ install: woof-linux-amd64
 	mkdir -p ~/.local/bin
 	mv woof-linux-amd64 ~/.local/bin/woof
 
-
 .PHONY: all
 all: clean woof-linux-amd64 woof-linux-arm woof-windows-amd64


### PR DESCRIPTION
When the `~/.local/bin` folder doesn't exist, `make install` fails. for some reason my system didn't had that directory.
now it creates the directory if it doesn't exist. 